### PR TITLE
Updating the helpline_receiver_list and helpline_receiver_form

### DIFF
--- a/application/models/helpline_model.php
+++ b/application/models/helpline_model.php
@@ -1536,14 +1536,15 @@ SUM(CASE WHEN helpline_call.direction =  'outbound-dial' THEN 1 ELSE 0 END) AS o
 		if(isset($data['phone'])){
 			$this->db->where('phone', '0' . $data['phone']);
 		}
-		$this->db->select("helpline_receiver.receiver_id, full_name, phone, email, CONCAT(district.district, '-' , state.state) as district, category, user_id, doctor, enable_outbound, app_id, activity_status,language,proficiency, CONCAT(helpline.note, ' - ', helpline.helpline) as helpline,helpline_receiver_note", false)
+		$this->db->select("helpline_receiver.receiver_id, full_name, phone, email, CONCAT(district.district, '-' , state.state) as district, category, user_id, doctor, enable_outbound, app_id, activity_status,GROUP_CONCAT(language) AS language,GROUP_CONCAT(proficiency) AS proficiency, CONCAT(helpline.note, ' - ', helpline.helpline) as helpline,helpline_receiver_note", false)
 		->from('helpline_receiver')
 		->join('helpline', 'helpline_receiver.helpline_id=helpline.helpline_id','left')
 		->join('district', 'helpline_receiver.district_id=district.district_id','left')
 		->join('helpline_receiver_language', 'helpline_receiver.receiver_id=helpline_receiver_language.receiver_id','left')
 		->join('language', 'language.language_id=helpline_receiver_language.language_id','left')
 		->join('state', 'district.state_id= state.state_id','left')
-		->order_by('full_name', 'asc');
+		->order_by('full_name', 'asc')
+		->group_by('receiver_id,full_name');
 		if ($default_rowsperpage !=0){
 			$this->db->limit($rows_per_page,$start);
 		}

--- a/application/views/pages/helpline_receiver_form.php
+++ b/application/views/pages/helpline_receiver_form.php
@@ -192,7 +192,7 @@ textarea {
 				<div class="col-xs-12 col-sm-12 col-md-6 col-lg-3">
 					<div class="form-horizontal">
 						<label for="district_id">District<font style="color:red">*</font></label>
-						<select id="district_id" name="user_id" class="" placeholder="-Enter User Name/Phone-">
+						<select id="district_id" name="district_id" class="" placeholder="-Enter User Name/Phone-">
 							<option value="">-Enter District-</option>
 						</select>
 					</div>

--- a/application/views/pages/helpline_receiver_list.php
+++ b/application/views/pages/helpline_receiver_list.php
@@ -396,9 +396,15 @@ echo "</select></li>";
         </td>
         <td>
         <?php 
-          foreach($proficiency as $key=>$val){
-            if($key == $a->proficiency){
-             echo $val;}} ?>
+          $keys = explode(',',$a->proficiency);
+
+            $proficiency_array = array();
+            foreach($keys as $key){
+                if(isset($proficiency[$key])){
+                  $proficiency_array[] = $proficiency[$key];}    
+                  } 
+            echo implode(", ", $proficiency_array);
+        ?>
         </td>
         <td>
             <?php echo $a->user_id ? 'Yes': 'No';?>


### PR DESCRIPTION
In order to display multiple languages associated with a user in a single row, the query for retrieving the list of users in helpline_receiver is now grouped by 'receiver_id'. And, the district_id select name in helpline_receiver_form has changed.